### PR TITLE
Use buttons to swap character models

### DIFF
--- a/VRoidHubLoader/Patches/ModelPageManagerPatch.cs
+++ b/VRoidHubLoader/Patches/ModelPageManagerPatch.cs
@@ -1,0 +1,54 @@
+﻿using CustomAvatarLoader.Settings;
+using HarmonyLib;
+using Il2Cpp;
+using MelonLoader;
+using UnityEngine.UI;
+using UnityEngine;
+using CustomAvatarLoader.Modules;
+
+namespace CustomAvatarLoader.Patches
+{
+    [HarmonyPatch(typeof(ModelPageManager), "Start")]
+    internal class ModelPageManagerPatch
+    {
+        protected static ISettingsProvider SettingsProvider { get; private set; }
+        protected static Logging.ILogger Logger { get; private set; }
+        protected static VrmLoaderModule LoaderModule { get; private set; }
+
+        public static void InitPatch(Logging.ILogger logger, ISettingsProvider provider, VrmLoaderModule module)
+        {
+            SettingsProvider = provider;
+            Logger = logger;
+            LoaderModule = module;
+        }
+
+        private static void Postfix(ModelPageManager __instance)
+        {
+            float offset = 0.32f;
+            foreach (string path in Directory.GetFiles(LoaderModule.VrmFolderPath).Where(f => f.EndsWith(".vrm")))
+            {
+                string file = Path.GetFileName(path);
+                string name = file.Split('.')[0];
+                GameObject button = DefaultControls.CreateButton(new DefaultControls.Resources());
+                button.transform.position = new Vector3(0.83f, offset, -1f);
+                button.transform.localScale = new Vector3(1.2f, 1.2f, 1f);
+                button.name = name + "_button";
+                button.GetComponentInChildren<Text>().text = name;
+                button.GetComponent<Button>().onClick.AddListener(new Action(() =>
+                {
+                    if (LoaderModule.LoadCharacter(path))
+                    {
+                        SettingsProvider.Set("vrmPath", path);
+                        MelonPreferences.Save();
+
+                        Logger.Debug("OnUpdate: VrmLoaderModule file chosen");
+                    }
+                }));
+                button.transform.SetParent(__instance.mikuButton.transform.parent.transform, false);
+                Logger.Info("Loaded VRM " + file);
+                offset -= 0.32f;
+            }
+            Logger.Debug("[Chara Loader] Custom menu buttons generated");
+        }
+    }
+}

--- a/VRoidHubLoader/VRoidHubLoader.csproj
+++ b/VRoidHubLoader/VRoidHubLoader.csproj
@@ -425,6 +425,7 @@
 		<Compile Include="Logging\PlayerLogManager.cs" />
 		<Compile Include="Modules\IModule.cs" />
 		<Compile Include="Modules\VrmLoaderModule.cs" />
+		<Compile Include="Patches\ModelPageManagerPatch.cs" />
 		<Compile Include="Settings\ISettingsProvider.cs" />
 		<Compile Include="Settings\MelonLoaderSettings.cs" />
 		<Compile Include="Versioning\GitHubTag.cs" />


### PR DESCRIPTION
This PR implements functionality to select a VRM via buttons in the in-game character selection menu instead of having to press F4. Upon first launch, a `VRM` folder is generated in the root game folder. The user must place all of their desired .vrm files into this folder. Each time the program is launched, the mod will scan through this folder and assign a button to each discovered vrm file. Navigating to the character selection menu and clicking on a button will load the respective custom model.

The F4 functionality has been replaced as a hotkey to quickly open the character selection menu, as suggested by @morphicschris. Other ideas tossed around were an importer to auto-import .vrms into the VRM folder, or keeping functionality of both. I am open to ideas on this topic.