### PR TITLE
Hot reload for model picker buttons

### DIFF
--- a/VRoidHubLoader/Patches/ModelPageManagerPatch.cs
+++ b/VRoidHubLoader/Patches/ModelPageManagerPatch.cs
@@ -1,4 +1,5 @@
-﻿using CustomAvatarLoader.Settings;
+﻿using System.Collections;
+using CustomAvatarLoader.Settings;
 using HarmonyLib;
 using Il2Cpp;
 using MelonLoader;
@@ -14,16 +15,70 @@ namespace CustomAvatarLoader.Patches
         protected static ISettingsProvider SettingsProvider { get; private set; }
         protected static Logging.ILogger Logger { get; private set; }
         protected static VrmLoaderModule LoaderModule { get; private set; }
+        private static FileSystemWatcher vrmWatcher;
+        private static ModelPageManager instance;
+        private static System.Timers.Timer debounceTimer;
 
         public static void InitPatch(Logging.ILogger logger, ISettingsProvider provider, VrmLoaderModule module)
         {
             SettingsProvider = provider;
             Logger = logger;
             LoaderModule = module;
+            
+            InitFileSystemWatcher();
+        }
+        
+        private static void InitFileSystemWatcher()
+        {
+            string vrmFolderPath = LoaderModule.VrmFolderPath;
+            vrmWatcher = new FileSystemWatcher(vrmFolderPath, "*.vrm");
+            vrmWatcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite;
+            vrmWatcher.Created += OnVrmFolderChanged;
+            vrmWatcher.Deleted += OnVrmFolderChanged;
+            vrmWatcher.EnableRaisingEvents = true;
+            
+            debounceTimer = new System.Timers.Timer(3000);
+            debounceTimer.AutoReset = false;
+            debounceTimer.Elapsed += (_, __) => RebuildButtons();
         }
 
+        private static void OnVrmFolderChanged(object sender, FileSystemEventArgs e)
+        {
+            Logger.Debug($"VRM file change detected: {e.ChangeType} - {e.FullPath}");
+            
+            if (debounceTimer.Enabled)
+            {
+                debounceTimer.Stop();
+            }
+            debounceTimer.Start();
+        }
+        
         private static void Postfix(ModelPageManager __instance)
         {
+            instance = __instance;
+            RebuildButtons();
+        }
+
+        private static void RebuildButtons()
+        {
+            if (instance == null) return;
+
+            MelonCoroutines.Start(RebuildButtonsCoroutine());
+        }
+
+        private static IEnumerator RebuildButtonsCoroutine()
+        {
+            // Delete the old buttons
+            Transform buttonParent = instance.mikuButton.transform.parent;
+            foreach (Transform child in buttonParent.GetComponentsInChildren<Transform>())
+            {
+                if (child.name.EndsWith("_button"))
+                {
+                    UnityEngine.Object.Destroy(child.gameObject);
+                }
+            }
+
+            // Regenerate the buttons
             float offset = 0.32f;
             foreach (string path in Directory.GetFiles(LoaderModule.VrmFolderPath).Where(f => f.EndsWith(".vrm")))
             {
@@ -31,7 +86,7 @@ namespace CustomAvatarLoader.Patches
                 string name = file.Split('.')[0];
                 GameObject button = DefaultControls.CreateButton(new DefaultControls.Resources());
                 button.transform.position = new Vector3(0.83f, offset, -1f);
-                RectTransform mikuButtonRect = __instance.mikuButton.GetComponent<RectTransform>();
+                RectTransform mikuButtonRect = instance.mikuButton.GetComponent<RectTransform>();
                 RectTransform buttonRect = button.GetComponent<RectTransform>();
                 buttonRect.sizeDelta = mikuButtonRect.sizeDelta;
                 button.name = name + "_button";
@@ -50,10 +105,12 @@ namespace CustomAvatarLoader.Patches
                         Logger.Debug("OnUpdate: VrmLoaderModule file chosen");
                     }
                 }));
-                button.transform.SetParent(__instance.mikuButton.transform.parent.transform, false);
+                button.transform.SetParent(instance.mikuButton.transform.parent.transform, false);
                 Logger.Info("Loaded VRM " + file);
                 offset -= 0.32f;
+                yield return null;
             }
+
             Logger.Debug("[Chara Loader] Custom menu buttons generated");
         }
     }


### PR DESCRIPTION
Uses FileSystemWatcher to listen for changes on the VRM folder and regenerates the buttons. There is a 3 second delay before the buttons are generated to make sure all the files are added. In my case, the delay was enough for even 128 VRM files added at the same time.