### PR TITLE
Message Boxes

### DIFF
--- a/VRoidHubLoader/Core.cs
+++ b/VRoidHubLoader/Core.cs
@@ -3,6 +3,7 @@
 namespace CustomAvatarLoader;
 
 using CustomAvatarLoader.Helpers;
+using CustomAvatarLoader.Messaging;
 using CustomAvatarLoader.Modules;
 using Logging;
 using MelonLoader;
@@ -20,6 +21,8 @@ public class Core : MelonMod
 
     protected virtual IServiceProvider ServiceProvider { get; private set; }
 
+    protected virtual IMessageProvider MessageProvider { get; private set; }
+
     protected virtual IEnumerable<IModule> Modules { get; private set; }
 
     public override void OnInitializeMelon()
@@ -31,6 +34,7 @@ public class Core : MelonMod
         Modules = ServiceProvider.GetServices<IModule>();
         Logger = ServiceProvider.GetService<ILogger>();
         SettingsProvider = ServiceProvider.GetService<ISettingsProvider>();
+        MessageProvider = ServiceProvider.GetService<IMessageProvider>();
 
         var versionChecker = new GitHubVersionChecker(RepositoryName, Logger);
         var updater = new Updater(RepositoryName, Logger);
@@ -76,6 +80,7 @@ public class Core : MelonMod
     {
         services.AddSingleton(typeof(MelonLogger.Instance), LoggerInstance);
         services.AddSingleton(typeof(ISettingsProvider), new MelonLoaderSettings("settings"));
+        services.AddSingleton(typeof(IMessageProvider), new MelonLoaderMessenger());
         services.AddScoped(typeof(ILogger), typeof(MelonLoaderLogger));
         services.AddScoped(typeof(IModule), typeof(VrmLoaderModule));
     }
@@ -86,5 +91,10 @@ public class Core : MelonMod
         {
             service.OnUpdate();
         }
+    }
+
+    public override void OnGUI()
+    {
+        MessageProvider.OnGUI();
     }
 }

--- a/VRoidHubLoader/Messaging/IMessageProvider.cs
+++ b/VRoidHubLoader/Messaging/IMessageProvider.cs
@@ -1,0 +1,14 @@
+﻿using UnityEngine;
+
+namespace CustomAvatarLoader.Messaging;
+
+public interface IMessageProvider
+{
+    bool HasWindowsOpen();
+
+    void ShowMessageBox(string title, string message);
+
+    void ShowMessageBox(string title, string message, Color color);
+
+    void OnGUI();
+}

--- a/VRoidHubLoader/Messaging/MelonLoaderMessenger.cs
+++ b/VRoidHubLoader/Messaging/MelonLoaderMessenger.cs
@@ -1,0 +1,46 @@
+﻿using Il2Cpp;
+using UnityEngine;
+
+namespace CustomAvatarLoader.Messaging;
+
+public class MelonLoaderMessenger : IMessageProvider
+{
+    private readonly List<MessageBox> OpenMessageBoxes = [];
+
+    public bool HasWindowsOpen()
+    {
+        return OpenMessageBoxes.Count > 0;
+    }
+
+    public void OnGUI()
+    {
+        for (int i = 0; i < OpenMessageBoxes.Count; i++)
+        {
+            MessageBox box = OpenMessageBoxes[i];
+            if (!box.Initialized)
+                box.Init();
+            box.Draw(i);
+        }
+    }
+
+    public void ShowMessageBox(string title, string message)
+    {
+        ShowMessageBox(title, message, Color.gray);
+    }
+
+    public void ShowMessageBox(string title, string message, Color color)
+    {
+        MessageBox box = new(title, message, color);
+        box.OnClose += OnMessageBoxClosed;
+        OpenMessageBoxes.Add(box);
+    }
+
+    private void OnMessageBoxClosed(object? sender, EventArgs e)
+    {
+        if (sender is MessageBox boxSender)
+        {
+            OpenMessageBoxes.Remove(boxSender);
+        }
+    }
+
+}

--- a/VRoidHubLoader/Messaging/MessageBox.cs
+++ b/VRoidHubLoader/Messaging/MessageBox.cs
@@ -1,0 +1,67 @@
+﻿using UnityEngine;
+
+namespace CustomAvatarLoader.Messaging
+{
+    public class MessageBox
+    {
+        protected string Title { get; private set; }
+        protected string Message { get; private set; }
+        protected Color Color { get; private set; }
+        public bool Initialized { get; private set; } = false;
+
+        private Rect Window;
+        private Vector2 Size;
+
+        public event EventHandler OnClose;
+
+        #pragma warning disable CS8618 // Suppress warnings about OnClose being null
+        public MessageBox(string title, string message)
+        {
+            Title = title;
+            Message = message;
+            Color = Color.gray;
+        }
+
+        public MessageBox(string title, string message, Color color)
+        {
+            Title = title;
+            Message = message;
+            Color = color;
+        }
+        #pragma warning restore CS8618
+
+        public void Init()
+        {
+            if (!Initialized)
+            {
+                GUI.skin.label.alignment = TextAnchor.MiddleCenter;
+                GUI.skin.button.alignment = TextAnchor.MiddleCenter;
+                Size = GUI.skin.label.CalcSize(new GUIContent(Message));
+                Window = new Rect(500, 500, Size.x + 120, Size.y + 90);
+                Initialized = true;
+            }
+        }
+
+        public void Draw(int windowID)
+        {
+            GUI.color = Color;
+            Window = GUI.Window(windowID, Window, (GUI.WindowFunction)DrawGUI, Title);
+        }
+
+        private void DrawGUI(int windowID)
+        {
+            GUI.Label(new Rect(60, 40, Size.x, Size.y), Message);
+            if (GUI.Button(new Rect((Window.width / 2) - 50, Window.height - 40, 100, 20), "Ok"))
+            {
+                OnOkButtonClicked();
+            }
+            GUI.DragWindow(new Rect(0, 0, 10000, 10000));
+        }
+
+        private void OnOkButtonClicked()
+        {
+            OnClose?.Invoke(this, EventArgs.Empty);
+        }
+
+    }
+}

--- a/VRoidHubLoader/Modules/VrmLoaderModule.cs
+++ b/VRoidHubLoader/Modules/VrmLoaderModule.cs
@@ -4,6 +4,7 @@ using CustomAvatarLoader.Settings;
 namespace CustomAvatarLoader.Modules;
 
 using CustomAvatarLoader.Helpers;
+using CustomAvatarLoader.Messaging;
 using CustomAvatarLoader.Patches;
 using Il2Cpp;
 using MelonLoader;
@@ -17,16 +18,19 @@ public class VrmLoaderModule : IModule
 {
     private bool init;
 
-    public VrmLoaderModule(ILogger logger, ISettingsProvider settingsProvider)
+    public VrmLoaderModule(ILogger logger, ISettingsProvider settingsProvider, IMessageProvider messageProvider)
     {
         Logger = logger;
         SettingsProvider = settingsProvider;
+        MessageProvider = messageProvider;
         VrmLoader = new VrmLoader(Logger);
     }
 
     protected virtual ILogger Logger { get; }
     
     protected virtual ISettingsProvider SettingsProvider { get; }
+
+    protected virtual IMessageProvider MessageProvider { get; }
 
     protected virtual VrmLoader VrmLoader { get; }
 

--- a/VRoidHubLoader/VRoidHubLoader.csproj
+++ b/VRoidHubLoader/VRoidHubLoader.csproj
@@ -423,6 +423,9 @@
 		<Compile Include="Logging\ILogger.cs" />
 		<Compile Include="Logging\MelonLoaderLogger.cs" />
 		<Compile Include="Logging\PlayerLogManager.cs" />
+		<Compile Include="Messaging\IMessageProvider.cs" />
+		<Compile Include="Messaging\MelonLoaderMessenger.cs" />
+		<Compile Include="Messaging\MessageBox.cs" />
 		<Compile Include="Modules\IModule.cs" />
 		<Compile Include="Modules\VrmLoaderModule.cs" />
 		<Compile Include="Patches\ModelPageManagerPatch.cs" />


### PR DESCRIPTION
This PR adds support for a basic message box system utilizing Unity's IMGUI. Message boxes can be customized by title, message, and color, and will auto-size depending on the length of the text. There can be multiple message boxes on the screen at once, and each one can be dragged individually. Each box comes with an "Ok" button that simply closes the message box.

I am creating this PR as a draft since the following things still need to be addressed:

- [ ] Message boxes spawn in the same spot every time. A coordinate-preset system should be created (probably using the character as an origin)
- [ ] Dragging a message box also drags the character. I tried many different solutions and patches, to no avail. `MenuManager.Instance.IsOpen`, while the best solution, is inlined and cannot be patched. Forcing this variable to true/false can create a desync (i.e. the menu being open but `IsOpen` is false). If there's a way to check if the menu is open without using `IsOpen` then forcing this variable would be the best solution.
- [ ] Message boxes should (probably) support more buttons than just "Ok"

Again, I am open to any ideas or suggestions for any of the above, however I think these points should be addressed before considering merging.
