### PR TITLE
Import button

### DIFF
--- a/VRoidHubLoader/Core.cs
+++ b/VRoidHubLoader/Core.cs
@@ -18,6 +18,7 @@ public static class Core
 
     public static ISettingsProvider Settings { get; private set; }
     public static VrmLoaderModule MainModule { get; private set; }
+    public static FileHelper FileHelper { get; private set; }
 
     public static void Init(ILogger logger, ISettingsProvider settings)
     {
@@ -29,6 +30,7 @@ public static class Core
     {
         var versionChecker = new GitHubVersionChecker(RepositoryName);
         var updater = new Updater(RepositoryName);
+        FileHelper = new FileHelper();
 
         var currentVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0";
 

--- a/VRoidHubLoader/Helpers/FileHelper.cs
+++ b/VRoidHubLoader/Helpers/FileHelper.cs
@@ -26,7 +26,7 @@ public class FileHelper
         ofn.fileTitle = new string(new char[64]);
         ofn.maxFileTitle = ofn.fileTitle.Length;
         ofn.initialDir = Core.MainModule.VrmFolderPath;
-        ofn.title = "Open VRM File";
+        ofn.title = "Import VRM File";
         ofn.flags = 0x00080000 | 0x00000008; // OFN_EXPLORER | OFN_FILEMUSTEXIST
 
         return ofn;

--- a/VRoidHubLoader/Helpers/FileHelper.cs
+++ b/VRoidHubLoader/Helpers/FileHelper.cs
@@ -1,10 +1,11 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Collections;
+using System.Runtime.InteropServices;
 
 namespace CustomAvatarLoader.Helpers;
 
 public class FileHelper
 {
-    public Task<string> OpenFileDialog()
+    public Task<string?> OpenFileDialog()
     {
         var ofn = GetOpenFileName();
 
@@ -24,7 +25,7 @@ public class FileHelper
         ofn.maxFile = ofn.file.Length;
         ofn.fileTitle = new string(new char[64]);
         ofn.maxFileTitle = ofn.fileTitle.Length;
-        ofn.initialDir = UnityEngine.Application.dataPath;
+        ofn.initialDir = Core.MainModule.VrmFolderPath;
         ofn.title = "Open VRM File";
         ofn.flags = 0x00080000 | 0x00000008; // OFN_EXPLORER | OFN_FILEMUSTEXIST
 

--- a/VRoidHubLoader/Helpers/Updater.cs
+++ b/VRoidHubLoader/Helpers/Updater.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
-using CustomAvatarLoader.Logging;
 
 namespace CustomAvatarLoader.Helpers;
 

--- a/VRoidHubLoader/Modules/VrmLoaderModule.cs
+++ b/VRoidHubLoader/Modules/VrmLoaderModule.cs
@@ -47,7 +47,7 @@ public class VrmLoaderModule : MonoBehaviour
         VrmLoader = new VrmLoader();
     }
 
-    private async void Update()
+    private void Update()
     {
         if (!init)
         {
@@ -79,7 +79,7 @@ public class VrmLoaderModule : MonoBehaviour
         {
             Core.Msg("OnUpdate: VrmLoaderModule F4 pressed");
 
-            await ImportVRM();
+            _ = ImportVRM();
         }
     }
 

--- a/VRoidHubLoader/Modules/VrmLoaderModule.cs
+++ b/VRoidHubLoader/Modules/VrmLoaderModule.cs
@@ -34,6 +34,8 @@ public class VrmLoaderModule : MonoBehaviour
     public readonly string VrmFolderPath = BepInEx.Paths.GameRootPath + @"\VRM";
 #endif
 
+    private string? ModelToApply = null;
+
     private void Awake()
     {
         if (!Directory.Exists(VrmFolderPath))
@@ -59,6 +61,20 @@ public class VrmLoaderModule : MonoBehaviour
             }
         }
 
+        // After selecting a model via F4/import, we have to wait a frame to actually apply the model
+        // Attempting to do so inside of ImportVRM() causes a AccessViolationException
+        if (ModelToApply != null)
+        {
+            if (LoadCharacter(ModelToApply))
+            {
+                Core.Settings.Set("vrmPath", ModelToApply);
+                Core.Settings.SaveSettings();
+
+                Core.Msg("Update: Model file chosen");
+                ModelToApply = null;
+            }
+        }
+
         if (Input.GetKeyDown(KeyCode.F4))
         {
             Core.Msg("OnUpdate: VrmLoaderModule F4 pressed");
@@ -76,12 +92,15 @@ public class VrmLoaderModule : MonoBehaviour
         {
             string fileName = Path.GetFileName(path);
             string destination = VrmFolderPath + '\\' + fileName;
-            if (!File.Exists(destination))
+            if (File.Exists(destination))
             {
-                File.Copy(path, destination);
-                ModelPageManagerPatch.SpawnButtons();
-                Core.Msg($"Copied {fileName} to VRM folder");
+                // TODO: allow the user to decide if the old file should be overwritten
+                Core.Warn("Duplicate model file detected. The old model file will be overwritten!");
             }
+            File.Copy(path, destination, true);
+            ModelPageManagerPatch.SpawnButtons();
+            Core.Msg($"Added {fileName} to VRM folder");
+            ModelToApply = destination;
         }
 
         // MenuManager is a singleton? sweet.


### PR DESCRIPTION
This PR adds an "Import..." button below the two original buttons in the character selection menu, and clicking this button will allow the user to import VRMs. When a VRM is imported, the file is copied to the mod's `VRM` folder, and a new button is created in the character selection menu, which will automatically open if it is not already open. As of now, the active model **will not** be swapped, and the user will have to click the newly created button to apply the model.

The PR also restores the original functionality of F4, which now simply mimicks the behavior of the import button. Some async methods have also been created to support the Windows file browser in both cases.